### PR TITLE
Consolidate multiple databases into single gameData.db

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,11 +201,28 @@ curl "http://localhost:3000/api/items?name=Darksteel&limit=10"
                                  ↓
               ┌────────────────────────────────────────────┐
               │          SQLite Databases                  │
-              │  - game.db (items, quests, etc.)           │
-              │  - fish.db (fish data)                     │
-              │  - profile.db (character progress)         │
+              │  - gameData.db (game reference data)       │
+              │  - userData.db (character progress)        │
               └────────────────────────────────────────────┘
 ```
+
+**Database Structure:**
+
+**gameData.db** (Read-Only Game Reference Data):
+- Items, recipes, and crafting data
+- Gathering nodes (Mining, Botany)
+- Fish database with catch requirements
+- Mounts, minions, and orchestrion rolls
+- Quests, titles, and achievements
+- All game reference data from FFXIV CSVs
+
+**userData.db** (User-Specific Progress):
+- Character profiles and settings
+- Quest completions and job progress
+- Fish catches and gathering logs
+- Crafted items and collection tracking
+- Bookmarks, goals, and session history
+- Everything you can import/export/sync
 
 **Key Design Principles:**
 
@@ -215,6 +232,7 @@ curl "http://localhost:3000/api/items?name=Darksteel&limit=10"
 - **Separation of Concerns**: Clear boundaries between presentation, API, business logic, and data layers
 - **Offline-First**: All data stored locally in SQLite
 - **RESTful Design**: Consistent API patterns across all endpoints
+- **Data Portability**: userData.db can be easily backed up, exported, or synced
 
 ## Installation
 
@@ -395,12 +413,30 @@ DEFAULT_SERVER=YourServer
 The game data CSVs are provided via a git submodule (xivapi/ffxiv-datamining). After cloning and initializing the submodule, seed the databases:
 
 ```bash
-# Seed all game data (items, recipes, gathering, collectibles)
+# Initialize user database (for new users)
+npx tsx scripts/init-user-db.ts
+
+# Seed all game data (items, recipes, gathering, collectibles, fish)
 npm run seed-game-data
+npm run seed-fish-data
 
 # Or seed selectively
 npm run seed-game-data -- --skip-gathering
 npm run seed-game-data -- --skip-collectibles
+```
+
+### Migrating from Old Database Structure
+
+If you have existing `profile.db`, `game.db`, or `fish.db` files from an older version:
+
+```bash
+# Automatically migrate to new consolidated structure
+npx tsx scripts/migrate-to-consolidated-db.ts
+
+# This will:
+# - Create userData.db from profile.db + user tracking data
+# - Create gameData.db from game.db + fish.db
+# - Backup your old databases
 ```
 
 ### Updating Game Data

--- a/data/gameData-schema.sql
+++ b/data/gameData-schema.sql
@@ -1,0 +1,564 @@
+-- ============================================================================
+-- EORZEA GAME DATA SCHEMA (gameData.db)
+-- ============================================================================
+-- Consolidated game reference database for FFXIV including:
+-- - Items (with sources and uses)
+-- - Crafting/Recipes
+-- - Gathering (Mining, Botany)
+-- - Fishing (Fish, Spots, Baits, Weather)
+-- - Collectibles (Mounts, Minions, Orchestrion Rolls)
+-- - Titles & Achievements
+-- - Reference Data (Jobs, Locations, Maps)
+--
+-- This database is READ-ONLY and contains no user-specific data.
+-- User progress is tracked separately in userData.db.
+-- ============================================================================
+
+-- ============================================================================
+-- ITEMS
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS items (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    icon INTEGER,
+    level_item INTEGER,
+    level_equip INTEGER,
+    rarity INTEGER, -- 1=Common, 2=Uncommon, 3=Rare, 4=Relic, 7=Aetherial
+    item_ui_category_id INTEGER,
+    item_search_category_id INTEGER,
+    stack_size INTEGER DEFAULT 1,
+    is_unique BOOLEAN DEFAULT 0,
+    is_untradable BOOLEAN DEFAULT 0,
+    is_dyeable BOOLEAN DEFAULT 0,
+    is_collectible BOOLEAN DEFAULT 0,
+    can_be_hq BOOLEAN DEFAULT 0,
+    price_mid INTEGER DEFAULT 0,
+    price_low INTEGER DEFAULT 0,
+    desynth_skill INTEGER,
+    is_crest_worthy BOOLEAN DEFAULT 0,
+    materialize_type INTEGER,
+    item_action_id INTEGER,
+    cast_time_s INTEGER,
+    cooldown_s INTEGER,
+    class_job_category INTEGER,
+    grand_company INTEGER,
+    item_series_id INTEGER,
+    base_param_modifier INTEGER,
+    model_main TEXT,
+    model_sub TEXT,
+    class_job_repair INTEGER,
+    item_repair_id INTEGER,
+    item_glamour_id INTEGER,
+    item_special_bonus INTEGER,
+    is_pvp BOOLEAN DEFAULT 0,
+    lot_size INTEGER,
+    item_sub_category INTEGER,
+    item_sort_category INTEGER,
+    additional_data TEXT, -- JSON for any extra fields
+    FOREIGN KEY (item_ui_category_id) REFERENCES item_ui_categories(id),
+    FOREIGN KEY (item_search_category_id) REFERENCES item_search_categories(id)
+);
+
+CREATE INDEX idx_items_name ON items(name);
+CREATE INDEX idx_items_level ON items(level_item);
+CREATE INDEX idx_items_ui_category ON items(item_ui_category_id);
+CREATE INDEX idx_items_search_category ON items(item_search_category_id);
+CREATE INDEX idx_items_rarity ON items(rarity);
+
+CREATE TABLE IF NOT EXISTS item_ui_categories (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    icon INTEGER,
+    order_minor INTEGER,
+    order_major INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS item_search_categories (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    category INTEGER,
+    order_major INTEGER,
+    order_minor INTEGER,
+    class_job INTEGER
+);
+
+-- Track where items come from
+CREATE TABLE IF NOT EXISTS item_sources (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    item_id INTEGER NOT NULL,
+    source_type TEXT NOT NULL, -- 'quest', 'crafting', 'gathering', 'monster', 'shop', 'achievement', 'treasure', 'dungeon', 'trial', 'raid'
+    source_id INTEGER, -- ID of the source (quest_id, recipe_id, gathering_point_id, etc.)
+    source_name TEXT, -- Human-readable name
+    source_details TEXT, -- JSON for additional info (location, drop rate, cost, etc.)
+    FOREIGN KEY (item_id) REFERENCES items(id)
+);
+
+CREATE INDEX idx_item_sources_item ON item_sources(item_id);
+CREATE INDEX idx_item_sources_type ON item_sources(source_type);
+CREATE INDEX idx_item_sources_source ON item_sources(source_id);
+
+-- Track what items are used for
+CREATE TABLE IF NOT EXISTS item_uses (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    item_id INTEGER NOT NULL,
+    use_type TEXT NOT NULL, -- 'recipe_ingredient', 'quest_required', 'leve_required', 'gc_supply', 'desynth'
+    use_id INTEGER, -- ID of what it's used for (recipe_id, quest_id, etc.)
+    use_name TEXT, -- Human-readable name
+    quantity_required INTEGER DEFAULT 1,
+    use_details TEXT, -- JSON for additional info
+    FOREIGN KEY (item_id) REFERENCES items(id)
+);
+
+CREATE INDEX idx_item_uses_item ON item_uses(item_id);
+CREATE INDEX idx_item_uses_type ON item_uses(use_type);
+CREATE INDEX idx_item_uses_use ON item_uses(use_id);
+
+-- ============================================================================
+-- CRAFTING & RECIPES
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS craft_types (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL, -- 'Carpenter', 'Blacksmith', 'Armorer', etc.
+    main_physical INTEGER,
+    sub_physical INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS recipes (
+    id INTEGER PRIMARY KEY,
+    number INTEGER, -- Recipe number shown in-game
+    craft_type_id INTEGER NOT NULL,
+    recipe_level_table_id INTEGER NOT NULL,
+    item_result_id INTEGER NOT NULL,
+    amount_result INTEGER DEFAULT 1,
+    material_quality_factor INTEGER,
+    difficulty_factor INTEGER,
+    quality_factor INTEGER,
+    durability_factor INTEGER,
+    required_craftsmanship INTEGER DEFAULT 0,
+    required_control INTEGER DEFAULT 0,
+    quick_synth_craftsmanship INTEGER,
+    quick_synth_control INTEGER,
+    secret_recipe_book_id INTEGER,
+    is_specialist BOOLEAN DEFAULT 0,
+    required_status_id INTEGER, -- Buff/status needed
+    item_required_id INTEGER, -- Item needed to craft
+    is_expert BOOLEAN DEFAULT 0,
+    can_quick_synth BOOLEAN DEFAULT 1,
+    can_hq BOOLEAN DEFAULT 1,
+    exp_reward INTEGER DEFAULT 0,
+    status_required TEXT,
+    is_secondary_result BOOLEAN DEFAULT 0,
+    patches TEXT, -- JSON array of patches this recipe was added/modified
+    FOREIGN KEY (craft_type_id) REFERENCES craft_types(id),
+    FOREIGN KEY (item_result_id) REFERENCES items(id)
+);
+
+CREATE INDEX idx_recipes_result ON recipes(item_result_id);
+CREATE INDEX idx_recipes_craft_type ON recipes(craft_type_id);
+CREATE INDEX idx_recipes_level ON recipes(recipe_level_table_id);
+
+CREATE TABLE IF NOT EXISTS recipe_level_tables (
+    id INTEGER PRIMARY KEY,
+    class_job_level INTEGER,
+    stars INTEGER DEFAULT 0,
+    suggestedCraftsmanship INTEGER DEFAULT 0,
+    suggestedControl INTEGER DEFAULT 0,
+    difficulty INTEGER DEFAULT 0,
+    quality INTEGER DEFAULT 0,
+    durability INTEGER DEFAULT 0,
+    conditionsFlag INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS recipe_ingredients (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    recipe_id INTEGER NOT NULL,
+    item_id INTEGER NOT NULL,
+    quantity INTEGER NOT NULL DEFAULT 1,
+    position INTEGER, -- Slot position (0-9)
+    FOREIGN KEY (recipe_id) REFERENCES recipes(id),
+    FOREIGN KEY (item_id) REFERENCES items(id)
+);
+
+CREATE INDEX idx_recipe_ingredients_recipe ON recipe_ingredients(recipe_id);
+CREATE INDEX idx_recipe_ingredients_item ON recipe_ingredients(item_id);
+
+-- ============================================================================
+-- GATHERING (Mining, Botany)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS gathering_types (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL -- 'Mining', 'Quarrying', 'Logging', 'Harvesting', 'Spearfishing'
+);
+
+CREATE TABLE IF NOT EXISTS gathering_point_base (
+    id INTEGER PRIMARY KEY,
+    gathering_type_id INTEGER NOT NULL,
+    gathering_level INTEGER NOT NULL,
+    is_limited BOOLEAN DEFAULT 0,
+    FOREIGN KEY (gathering_type_id) REFERENCES gathering_types(id)
+);
+
+CREATE TABLE IF NOT EXISTS gathering_points (
+    id INTEGER PRIMARY KEY,
+    gathering_point_base_id INTEGER NOT NULL,
+    place_name_id INTEGER,
+    territory_type_id INTEGER,
+    map_id INTEGER,
+    pos_x REAL,
+    pos_y REAL,
+    radius INTEGER DEFAULT 100,
+    gathering_sub_category_id INTEGER,
+    FOREIGN KEY (gathering_point_base_id) REFERENCES gathering_point_base(id),
+    FOREIGN KEY (place_name_id) REFERENCES place_names(id),
+    FOREIGN KEY (territory_type_id) REFERENCES territory_types(id)
+);
+
+CREATE INDEX idx_gathering_points_base ON gathering_points(gathering_point_base_id);
+CREATE INDEX idx_gathering_points_territory ON gathering_points(territory_type_id);
+CREATE INDEX idx_gathering_points_place ON gathering_points(place_name_id);
+
+CREATE TABLE IF NOT EXISTS gathering_items (
+    id INTEGER PRIMARY KEY,
+    item_id INTEGER NOT NULL,
+    gathering_item_level_id INTEGER,
+    is_hidden BOOLEAN DEFAULT 0,
+    FOREIGN KEY (item_id) REFERENCES items(id)
+);
+
+CREATE TABLE IF NOT EXISTS gathering_item_points (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    gathering_point_id INTEGER NOT NULL,
+    gathering_item_id INTEGER NOT NULL,
+    FOREIGN KEY (gathering_point_id) REFERENCES gathering_points(id),
+    FOREIGN KEY (gathering_item_id) REFERENCES gathering_items(id)
+);
+
+CREATE INDEX idx_gathering_item_points_point ON gathering_item_points(gathering_point_id);
+CREATE INDEX idx_gathering_item_points_item ON gathering_item_points(gathering_item_id);
+
+-- ============================================================================
+-- FISHING
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS fish (
+    id INTEGER PRIMARY KEY,
+    patch REAL,
+    location_id INTEGER,
+    start_hour INTEGER NOT NULL,
+    end_hour INTEGER NOT NULL,
+    weather_set TEXT, -- JSON array
+    previous_weather_set TEXT, -- JSON array
+    best_catch_path TEXT, -- JSON array of bait IDs
+    predators TEXT, -- JSON array
+    intuition_length INTEGER,
+    folklore BOOLEAN,
+    collectable BOOLEAN,
+    fish_eyes BOOLEAN NOT NULL,
+    big_fish BOOLEAN NOT NULL,
+    snagging BOOLEAN,
+    lure INTEGER,
+    hookset TEXT,
+    tug TEXT,
+    gig TEXT,
+    aquarium_water TEXT,
+    aquarium_size INTEGER,
+    data_missing BOOLEAN,
+    FOREIGN KEY (location_id) REFERENCES fishing_spots(id)
+);
+
+CREATE INDEX idx_fish_big ON fish(big_fish);
+CREATE INDEX idx_fish_patch ON fish(patch);
+CREATE INDEX idx_fish_location ON fish(location_id);
+
+CREATE TABLE IF NOT EXISTS fishing_spots (
+    id INTEGER PRIMARY KEY,
+    zone_id INTEGER,
+    territory INTEGER,
+    x REAL,
+    y REAL,
+    radius REAL,
+    category INTEGER,
+    FOREIGN KEY (zone_id) REFERENCES zones(id)
+);
+
+CREATE INDEX idx_fishing_spots_zone ON fishing_spots(zone_id);
+
+CREATE TABLE IF NOT EXISTS baits (
+    id INTEGER PRIMARY KEY,
+    icon INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS weather_types (
+    id INTEGER PRIMARY KEY,
+    icon INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS weather_names (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+CREATE INDEX idx_weather_names_name ON weather_names(name);
+
+CREATE TABLE IF NOT EXISTS weather_rates (
+    id INTEGER PRIMARY KEY,
+    map_id INTEGER,
+    map_scale INTEGER,
+    zone_id INTEGER,
+    region_id INTEGER,
+    rates TEXT NOT NULL, -- JSON array of [weather, rate]
+    FOREIGN KEY (zone_id) REFERENCES zones(id),
+    FOREIGN KEY (region_id) REFERENCES regions(id)
+);
+
+CREATE INDEX idx_weather_rates_zone ON weather_rates(zone_id);
+CREATE INDEX idx_weather_rates_region ON weather_rates(region_id);
+
+CREATE TABLE IF NOT EXISTS zones (
+    id INTEGER PRIMARY KEY,
+    region_id INTEGER,
+    weather_rate INTEGER,
+    FOREIGN KEY (region_id) REFERENCES regions(id)
+);
+
+CREATE TABLE IF NOT EXISTS regions (
+    id INTEGER PRIMARY KEY
+);
+
+-- ============================================================================
+-- COLLECTIBLES (Mounts, Minions, Orchestrion)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS mounts (
+    id INTEGER PRIMARY KEY,
+    singular TEXT NOT NULL,
+    plural TEXT,
+    name TEXT, -- Display name (may differ from singular)
+    description TEXT,
+    enhanced_description TEXT,
+    tooltip TEXT,
+    move_speed INTEGER, -- Ground movement speed
+    fly_speed INTEGER, -- Flying speed
+    is_flying BOOLEAN DEFAULT 0,
+    icon INTEGER,
+    ui_priority INTEGER,
+    ride_height INTEGER,
+    is_aquatic BOOLEAN DEFAULT 0,
+    is_seats INTEGER DEFAULT 1, -- Number of seats
+    extra_seats INTEGER DEFAULT 0,
+    order_major INTEGER,
+    order_minor INTEGER,
+    icon_smart_id INTEGER,
+    is_airborne BOOLEAN DEFAULT 0,
+    is_emote BOOLEAN DEFAULT 0
+);
+
+CREATE INDEX idx_mounts_name ON mounts(singular);
+CREATE INDEX idx_mounts_flying ON mounts(is_flying);
+
+CREATE TABLE IF NOT EXISTS companions (
+    id INTEGER PRIMARY KEY,
+    singular TEXT NOT NULL,
+    plural TEXT,
+    name TEXT,
+    description TEXT,
+    enhanced_description TEXT,
+    tooltip TEXT,
+    behavior_id INTEGER,
+    icon INTEGER,
+    order_major INTEGER,
+    order_minor INTEGER,
+    cost INTEGER, -- Summoning cost if applicable
+    hp INTEGER,
+    skill_angle INTEGER,
+    skill_cost INTEGER,
+    is_battle BOOLEAN DEFAULT 0, -- Can it fight?
+    monster_note_target_id INTEGER
+);
+
+CREATE INDEX idx_companions_name ON companions(singular);
+
+CREATE TABLE IF NOT EXISTS orchestrion_rolls (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    icon INTEGER,
+    orchestrion_category_id INTEGER,
+    order_major INTEGER,
+    order_minor INTEGER,
+    FOREIGN KEY (orchestrion_category_id) REFERENCES orchestrion_categories(id)
+);
+
+CREATE INDEX idx_orchestrion_name ON orchestrion_rolls(name);
+CREATE INDEX idx_orchestrion_category ON orchestrion_rolls(orchestrion_category_id);
+
+CREATE TABLE IF NOT EXISTS orchestrion_categories (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    order_major INTEGER,
+    order_minor INTEGER
+);
+
+-- Track how to obtain collectibles
+CREATE TABLE IF NOT EXISTS collectible_sources (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    collectible_type TEXT NOT NULL, -- 'mount', 'companion', 'orchestrion'
+    collectible_id INTEGER NOT NULL,
+    source_type TEXT NOT NULL, -- 'quest', 'achievement', 'shop', 'dungeon', 'trial', 'raid', 'crafting', 'gathering', 'event', 'mogstation'
+    source_id INTEGER,
+    source_name TEXT,
+    source_details TEXT, -- JSON (cost, requirements, drop rate, etc.)
+    UNIQUE(collectible_type, collectible_id, source_type, source_id)
+);
+
+CREATE INDEX idx_collectible_sources_collectible ON collectible_sources(collectible_type, collectible_id);
+CREATE INDEX idx_collectible_sources_type ON collectible_sources(source_type);
+
+-- ============================================================================
+-- TITLES & ACHIEVEMENTS
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS titles (
+    id INTEGER PRIMARY KEY,
+    name_masculine TEXT NOT NULL,
+    name_feminine TEXT NOT NULL,
+    is_prefix BOOLEAN NOT NULL,
+    sort_order INTEGER
+);
+
+CREATE INDEX idx_titles_name ON titles(name_masculine);
+
+CREATE TABLE IF NOT EXISTS achievements (
+    id INTEGER PRIMARY KEY,
+    category_id INTEGER,
+    name TEXT NOT NULL,
+    description TEXT,
+    points INTEGER,
+    title_reward_id INTEGER,
+    item_reward_id INTEGER,
+    icon INTEGER,
+    achievement_type INTEGER,
+    FOREIGN KEY (title_reward_id) REFERENCES titles(id),
+    FOREIGN KEY (item_reward_id) REFERENCES items(id)
+);
+
+CREATE INDEX idx_achievements_name ON achievements(name);
+CREATE INDEX idx_achievements_category ON achievements(category_id);
+CREATE INDEX idx_achievements_title_reward ON achievements(title_reward_id);
+
+-- ============================================================================
+-- REFERENCE TABLES
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS class_jobs (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    abbreviation TEXT,
+    class_job_category INTEGER,
+    starting_level INTEGER DEFAULT 1,
+    modifier_hp INTEGER,
+    modifier_mp INTEGER,
+    modifier_str INTEGER,
+    modifier_vit INTEGER,
+    modifier_dex INTEGER,
+    modifier_int INTEGER,
+    modifier_mnd INTEGER,
+    role INTEGER, -- 1=Tank, 2=Melee DPS, 3=Ranged DPS, 4=Healer, etc.
+    is_limited_job BOOLEAN DEFAULT 0,
+    can_queue_for_duty BOOLEAN DEFAULT 1,
+    item_starting_weapon INTEGER,
+    item_soul_crystal INTEGER,
+    primary_stat TEXT,
+    unlock_quest_id INTEGER,
+    job_index INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS place_names (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    name_plural TEXT,
+    name_no_article TEXT
+);
+
+CREATE TABLE IF NOT EXISTS territory_types (
+    id INTEGER PRIMARY KEY,
+    name TEXT,
+    place_name_id INTEGER,
+    region_place_name_id INTEGER,
+    zone_place_name_id INTEGER,
+    map_id INTEGER,
+    territory_intended_use INTEGER, -- 0=Overworld, 1=City, 2=Dungeon, etc.
+    is_pvp BOOLEAN DEFAULT 0,
+    mount_allowed BOOLEAN DEFAULT 1,
+    is_indoor BOOLEAN DEFAULT 0,
+    weather_rate INTEGER,
+    bg_path TEXT,
+    FOREIGN KEY (place_name_id) REFERENCES place_names(id)
+);
+
+CREATE TABLE IF NOT EXISTS maps (
+    id INTEGER PRIMARY KEY,
+    place_name_id INTEGER,
+    place_name_region_id INTEGER,
+    place_name_sub_id INTEGER,
+    territory_type_id INTEGER,
+    size_factor INTEGER,
+    offset_x INTEGER,
+    offset_y INTEGER,
+    map_marker_range INTEGER,
+    discovery_array_byte INTEGER,
+    discovery_index INTEGER,
+    hierarchy INTEGER,
+    priority_ui INTEGER,
+    priority_category_ui INTEGER,
+    is_event BOOLEAN DEFAULT 0,
+    FOREIGN KEY (place_name_id) REFERENCES place_names(id),
+    FOREIGN KEY (territory_type_id) REFERENCES territory_types(id)
+);
+
+-- ============================================================================
+-- VIEWS FOR CONVENIENT QUERIES
+-- ============================================================================
+
+-- View for complete item information with categories
+CREATE VIEW IF NOT EXISTS v_items_complete AS
+SELECT
+    i.*,
+    uic.name as ui_category_name,
+    sc.name as search_category_name
+FROM items i
+LEFT JOIN item_ui_categories uic ON i.item_ui_category_id = uic.id
+LEFT JOIN item_search_categories sc ON i.item_search_category_id = sc.id;
+
+-- View for recipes with result item names
+CREATE VIEW IF NOT EXISTS v_recipes_complete AS
+SELECT
+    r.*,
+    i.name as result_item_name,
+    ct.name as craft_type_name,
+    rlt.class_job_level,
+    rlt.stars
+FROM recipes r
+JOIN items i ON r.item_result_id = i.id
+JOIN craft_types ct ON r.craft_type_id = ct.id
+LEFT JOIN recipe_level_tables rlt ON r.recipe_level_table_id = rlt.id;
+
+-- View for gathering nodes with locations
+CREATE VIEW IF NOT EXISTS v_gathering_points_complete AS
+SELECT
+    gp.*,
+    gpb.gathering_type_id,
+    gpb.gathering_level,
+    gpb.is_limited,
+    gt.name as gathering_type_name,
+    pn.name as place_name,
+    tt.name as territory_name
+FROM gathering_points gp
+JOIN gathering_point_base gpb ON gp.gathering_point_base_id = gpb.id
+JOIN gathering_types gt ON gpb.gathering_type_id = gt.id
+LEFT JOIN place_names pn ON gp.place_name_id = pn.id
+LEFT JOIN territory_types tt ON gp.territory_type_id = tt.id;

--- a/data/userData-schema.sql
+++ b/data/userData-schema.sql
@@ -1,0 +1,261 @@
+-- ============================================================================
+-- EORZEA USER DATA SCHEMA (userData.db)
+-- ============================================================================
+-- User-specific database for FFXIV character progress tracking including:
+-- - Characters (multi-character support with Lodestone sync)
+-- - Job Progress
+-- - Quest Completions
+-- - Fishing Log
+-- - Gathering & Crafting Progress
+-- - Collectibles (Mounts, Minions, Orchestrion)
+-- - Titles & Achievements
+-- - Bookmarks & Goals
+-- - Session History
+--
+-- This database is READ/WRITE and contains all user-specific data.
+-- It references gameData.db for item names, recipes, locations, etc.
+-- This is the database that should be backed up, exported, and synced.
+-- ============================================================================
+
+PRAGMA foreign_keys = ON;
+
+-- ============================================================================
+-- CHARACTERS
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS characters (
+    id TEXT PRIMARY KEY,              -- Lodestone ID
+    name TEXT NOT NULL,
+    server TEXT NOT NULL,
+    data_center TEXT,
+    last_synced_at INTEGER,           -- Unix timestamp (milliseconds)
+    created_at INTEGER NOT NULL,
+    is_active BOOLEAN DEFAULT 1,      -- Current active character
+    notes TEXT,
+
+    -- Cached Lodestone data (updated only during sync)
+    avatar_url TEXT,
+    title TEXT,
+    free_company TEXT
+);
+
+-- ============================================================================
+-- JOB PROGRESS
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS job_progress (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    character_id TEXT NOT NULL,
+    job_name TEXT NOT NULL,
+    level INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    FOREIGN KEY (character_id) REFERENCES characters(id) ON DELETE CASCADE,
+    UNIQUE(character_id, job_name)
+);
+
+CREATE INDEX idx_job_progress_char ON job_progress(character_id);
+
+-- ============================================================================
+-- QUEST TRACKING
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS completed_quests (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    character_id TEXT NOT NULL,
+    quest_id INTEGER NOT NULL,           -- References gameData.db quests table (when implemented)
+    completed_at INTEGER NOT NULL,
+    notes TEXT,
+    source TEXT DEFAULT 'manual',        -- 'manual', 'sync_inferred', 'sync_confirmed'
+    confidence INTEGER,                   -- 0-100 for inferred completions
+    inferred_from INTEGER,               -- achievement_id that caused inference
+    FOREIGN KEY (character_id) REFERENCES characters(id) ON DELETE CASCADE,
+    UNIQUE(character_id, quest_id)
+);
+
+CREATE INDEX idx_completed_quests_char ON completed_quests(character_id);
+CREATE INDEX idx_completed_quests_quest ON completed_quests(quest_id);
+
+-- ============================================================================
+-- FISHING LOG
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS caught_fish (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    character_id TEXT NOT NULL,
+    fish_id INTEGER NOT NULL,            -- References gameData.db fish table
+    caught_at INTEGER NOT NULL,
+    location_id INTEGER,                  -- References gameData.db fishing_spots table
+    notes TEXT,
+    FOREIGN KEY (character_id) REFERENCES characters(id) ON DELETE CASCADE,
+    UNIQUE(character_id, fish_id)
+);
+
+CREATE INDEX idx_caught_fish_char ON caught_fish(character_id);
+CREATE INDEX idx_caught_fish_fish ON caught_fish(fish_id);
+
+-- ============================================================================
+-- GATHERING PROGRESS
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS gathered_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    character_id TEXT NOT NULL,
+    item_id INTEGER NOT NULL,            -- References gameData.db items table
+    gathering_point_id INTEGER,           -- References gameData.db gathering_points table
+    gathered_at INTEGER NOT NULL,         -- Unix timestamp (milliseconds)
+    is_hq BOOLEAN DEFAULT 0,
+    notes TEXT,
+    FOREIGN KEY (character_id) REFERENCES characters(id) ON DELETE CASCADE,
+    UNIQUE(character_id, item_id, gathering_point_id)
+);
+
+CREATE INDEX idx_gathered_items_character ON gathered_items(character_id);
+CREATE INDEX idx_gathered_items_item ON gathered_items(item_id);
+
+-- ============================================================================
+-- CRAFTING PROGRESS
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS crafted_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    character_id TEXT NOT NULL,
+    recipe_id INTEGER NOT NULL,          -- References gameData.db recipes table
+    item_id INTEGER NOT NULL,            -- References gameData.db items table
+    crafted_at INTEGER NOT NULL,         -- Unix timestamp (milliseconds)
+    is_hq BOOLEAN DEFAULT 0,
+    is_collectible BOOLEAN DEFAULT 0,
+    collectibility INTEGER,
+    notes TEXT,
+    FOREIGN KEY (character_id) REFERENCES characters(id) ON DELETE CASCADE,
+    UNIQUE(character_id, recipe_id)
+);
+
+CREATE INDEX idx_crafted_items_character ON crafted_items(character_id);
+CREATE INDEX idx_crafted_items_recipe ON crafted_items(recipe_id);
+
+-- ============================================================================
+-- COLLECTIBLES TRACKING
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS obtained_mounts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    character_id TEXT NOT NULL,
+    mount_id INTEGER NOT NULL,           -- References gameData.db mounts table
+    obtained_at INTEGER NOT NULL,        -- Unix timestamp (milliseconds)
+    obtained_from TEXT,                   -- 'quest', 'achievement', 'shop', etc.
+    notes TEXT,
+    FOREIGN KEY (character_id) REFERENCES characters(id) ON DELETE CASCADE,
+    UNIQUE(character_id, mount_id)
+);
+
+CREATE INDEX idx_obtained_mounts_character ON obtained_mounts(character_id);
+
+CREATE TABLE IF NOT EXISTS obtained_companions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    character_id TEXT NOT NULL,
+    companion_id INTEGER NOT NULL,       -- References gameData.db companions table
+    obtained_at INTEGER NOT NULL,
+    obtained_from TEXT,
+    notes TEXT,
+    FOREIGN KEY (character_id) REFERENCES characters(id) ON DELETE CASCADE,
+    UNIQUE(character_id, companion_id)
+);
+
+CREATE INDEX idx_obtained_companions_character ON obtained_companions(character_id);
+
+CREATE TABLE IF NOT EXISTS obtained_orchestrion (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    character_id TEXT NOT NULL,
+    orchestrion_id INTEGER NOT NULL,     -- References gameData.db orchestrion_rolls table
+    obtained_at INTEGER NOT NULL,
+    obtained_from TEXT,
+    notes TEXT,
+    FOREIGN KEY (character_id) REFERENCES characters(id) ON DELETE CASCADE,
+    UNIQUE(character_id, orchestrion_id)
+);
+
+CREATE INDEX idx_obtained_orchestrion_character ON obtained_orchestrion(character_id);
+
+-- ============================================================================
+-- TITLES & ACHIEVEMENTS
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS unlocked_titles (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    character_id TEXT NOT NULL,
+    title_id INTEGER NOT NULL,           -- References gameData.db titles table
+    unlocked_at INTEGER NOT NULL,
+    source TEXT DEFAULT 'manual',        -- 'manual', 'lodestone_sync', 'achievement'
+    source_id INTEGER,                    -- achievement_id if from achievement
+    notes TEXT,
+    FOREIGN KEY (character_id) REFERENCES characters(id) ON DELETE CASCADE,
+    UNIQUE(character_id, title_id)
+);
+
+CREATE INDEX idx_unlocked_titles_char ON unlocked_titles(character_id);
+CREATE INDEX idx_unlocked_titles_title ON unlocked_titles(title_id);
+
+CREATE TABLE IF NOT EXISTS unlocked_achievements (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    character_id TEXT NOT NULL,
+    achievement_id INTEGER NOT NULL,     -- References gameData.db achievements table
+    unlocked_at INTEGER NOT NULL,
+    source TEXT DEFAULT 'manual',        -- 'manual', 'lodestone_sync'
+    notes TEXT,
+    FOREIGN KEY (character_id) REFERENCES characters(id) ON DELETE CASCADE,
+    UNIQUE(character_id, achievement_id)
+);
+
+CREATE INDEX idx_unlocked_achievements_char ON unlocked_achievements(character_id);
+CREATE INDEX idx_unlocked_achievements_achievement ON unlocked_achievements(achievement_id);
+
+-- ============================================================================
+-- BOOKMARKS & GOALS
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS bookmarks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    character_id TEXT NOT NULL,
+    type TEXT NOT NULL,                  -- 'quest', 'fish', 'location', 'item', 'recipe'
+    item_id INTEGER NOT NULL,            -- ID in the respective gameData.db table
+    notes TEXT,
+    priority INTEGER DEFAULT 0,          -- 0=normal, 1=high
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (character_id) REFERENCES characters(id) ON DELETE CASCADE,
+    UNIQUE(character_id, type, item_id)
+);
+
+CREATE INDEX idx_bookmarks_char ON bookmarks(character_id);
+CREATE INDEX idx_bookmarks_type ON bookmarks(type);
+
+CREATE TABLE IF NOT EXISTS goals (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    character_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT,
+    type TEXT,                           -- 'quest', 'fish', 'level', 'custom'
+    target_value INTEGER,
+    current_value INTEGER DEFAULT 0,
+    completed BOOLEAN DEFAULT 0,
+    created_at INTEGER NOT NULL,
+    completed_at INTEGER,
+    FOREIGN KEY (character_id) REFERENCES characters(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_goals_char ON goals(character_id);
+CREATE INDEX idx_goals_completed ON goals(completed);
+
+-- ============================================================================
+-- SESSION HISTORY
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS session_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    character_id TEXT,
+    command TEXT NOT NULL,
+    args TEXT,                           -- JSON
+    timestamp INTEGER NOT NULL,
+    FOREIGN KEY (character_id) REFERENCES characters(id) ON DELETE SET NULL
+);
+
+CREATE INDEX idx_session_history_timestamp ON session_history(timestamp);

--- a/scripts/create-test-dbs.ts
+++ b/scripts/create-test-dbs.ts
@@ -16,11 +16,11 @@ if (!existsSync(DATA_DIR)) {
 
 console.log('Creating test databases...\n');
 
-// Create fish.db
-console.log('📦 Creating data/fish.db...');
-const fishDb = new Database(join(DATA_DIR, 'fish.db'));
+// Create gameData.db
+console.log('📦 Creating data/gameData.db...');
+const gameDb = new Database(join(DATA_DIR, 'gameData.db'));
 
-fishDb.exec(`
+gameDb.exec(`
   -- Fish table
   CREATE TABLE IF NOT EXISTS fish (
     id INTEGER PRIMARY KEY,
@@ -106,16 +106,7 @@ fishDb.exec(`
   VALUES (1, 1, 1, 100.0, 100.0, 5.0, 1);
   INSERT OR IGNORE INTO zones (id, name) VALUES (1, 'Test Zone');
   INSERT OR IGNORE INTO weather_names (id, name) VALUES (1, 'Clear Skies');
-`);
 
-fishDb.close();
-console.log('✅ fish.db created\n');
-
-// Create game.db
-console.log('📦 Creating data/game.db...');
-const gameDb = new Database(join(DATA_DIR, 'game.db'));
-
-gameDb.exec(`
   -- Items table
   CREATE TABLE IF NOT EXISTS items (
     id INTEGER PRIMARY KEY,
@@ -340,8 +331,31 @@ gameDb.exec(`
 `);
 
 gameDb.close();
-console.log('✅ game.db created\n');
+console.log('✅ gameData.db created\n');
+
+// Create userData.db
+console.log('📦 Creating data/userData.db...');
+const userDb = new Database(join(DATA_DIR, 'userData.db'));
+
+userDb.exec(`
+  -- Characters table
+  CREATE TABLE IF NOT EXISTS characters (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    server TEXT NOT NULL,
+    data_center TEXT,
+    created_at INTEGER NOT NULL,
+    is_active BOOLEAN DEFAULT 1
+  );
+
+  -- Insert test character
+  INSERT OR IGNORE INTO characters (id, name, server, created_at)
+  VALUES ('test-123', 'Test Character', 'Test Server', ${Date.now()});
+`);
+
+userDb.close();
+console.log('✅ userData.db created\n');
 
 console.log('🎉 Test databases created successfully!');
-console.log('   data/fish.db - Fish tracking database');
-console.log('   data/game.db - Quest, items, crafting, gathering, collectibles database');
+console.log('   data/gameData.db - Game reference data (items, quests, fish, crafting, etc.)');
+console.log('   data/userData.db - User-specific data (characters, progress, bookmarks)');

--- a/scripts/init-user-db.ts
+++ b/scripts/init-user-db.ts
@@ -1,0 +1,75 @@
+#!/usr/bin/env tsx
+/**
+ * Initialize User Database
+ *
+ * Creates a fresh userData.db with the proper schema.
+ * This is for new users who don't have an existing profile.db to migrate.
+ */
+
+import Database from 'better-sqlite3';
+import { join } from 'path';
+import { existsSync, readFileSync } from 'fs';
+
+const DATA_DIR = join(process.cwd(), 'data');
+const USER_DB_PATH = join(DATA_DIR, 'userData.db');
+const SCHEMA_PATH = join(DATA_DIR, 'userData-schema.sql');
+
+function log(emoji: string, message: string) {
+  console.log(`${emoji} ${message}`);
+}
+
+function error(message: string) {
+  console.error(`❌ ${message}`);
+  process.exit(1);
+}
+
+async function main() {
+  console.log('🔧 Initialize User Database');
+  console.log('===========================\n');
+
+  // Check if database already exists
+  if (existsSync(USER_DB_PATH)) {
+    error(`userData.db already exists at ${USER_DB_PATH}`);
+    console.log('If you want to recreate it, please delete or rename the existing file first.');
+    return;
+  }
+
+  // Check if schema file exists
+  if (!existsSync(SCHEMA_PATH)) {
+    error(`Schema file not found: ${SCHEMA_PATH}`);
+  }
+
+  log('📋', 'Reading schema...');
+  const schema = readFileSync(SCHEMA_PATH, 'utf-8');
+
+  log('🗄️', 'Creating userData.db...');
+  const db = new Database(USER_DB_PATH);
+
+  try {
+    // Execute schema
+    db.exec(schema);
+    log('✅', 'Schema applied successfully');
+
+    // Verify tables were created
+    const tables = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' ORDER BY name`)
+      .all() as { name: string }[];
+
+    log('📊', `Created ${tables.length} tables:`);
+    for (const { name } of tables) {
+      log('  •', name);
+    }
+  } catch (err) {
+    error(`Failed to create database: ${err}`);
+  } finally {
+    db.close();
+  }
+
+  console.log('\n===========================');
+  console.log('✅ User database initialized!');
+  console.log(`📁 Database: ${USER_DB_PATH}`);
+  console.log('\nYou can now start adding characters and tracking progress.');
+  console.log('===========================\n');
+}
+
+main();

--- a/scripts/migrate-to-consolidated-db.ts
+++ b/scripts/migrate-to-consolidated-db.ts
@@ -1,0 +1,329 @@
+#!/usr/bin/env tsx
+/**
+ * Migrate from old database structure to new consolidated structure
+ *
+ * Old structure:
+ * - profile.db (user data)
+ * - game.db (game data + user tracking)
+ * - fish.db (fishing data)
+ *
+ * New structure:
+ * - userData.db (all user data)
+ * - gameData.db (all game reference data)
+ *
+ * This script:
+ * 1. Creates userData.db from profile.db + user tracking tables from game.db
+ * 2. Creates gameData.db from game.db + fish.db (excluding user tracking tables)
+ */
+
+import Database from 'better-sqlite3';
+import { join } from 'path';
+import { existsSync, copyFileSync, readFileSync } from 'fs';
+
+const DATA_DIR = join(process.cwd(), 'data');
+
+// Old database paths
+const OLD_PROFILE_DB = join(DATA_DIR, 'profile.db');
+const OLD_GAME_DB = join(DATA_DIR, 'game.db');
+const OLD_FISH_DB = join(DATA_DIR, 'fish.db');
+
+// New database paths
+const NEW_USER_DB = join(DATA_DIR, 'userData.db');
+const NEW_GAME_DB = join(DATA_DIR, 'gameData.db');
+
+// Backup paths
+const BACKUP_PROFILE_DB = join(DATA_DIR, 'profile.db.backup');
+const BACKUP_GAME_DB = join(DATA_DIR, 'game.db.backup');
+const BACKUP_FISH_DB = join(DATA_DIR, 'fish.db.backup');
+
+// Schema paths
+const USER_SCHEMA_PATH = join(DATA_DIR, 'userData-schema.sql');
+const GAME_SCHEMA_PATH = join(DATA_DIR, 'gameData-schema.sql');
+
+function log(emoji: string, message: string) {
+  console.log(`${emoji} ${message}`);
+}
+
+function error(message: string) {
+  console.error(`❌ ${message}`);
+}
+
+function checkOldDatabases(): boolean {
+  const profileExists = existsSync(OLD_PROFILE_DB);
+  const gameExists = existsSync(OLD_GAME_DB);
+  const fishExists = existsSync(OLD_FISH_DB);
+
+  if (!profileExists && !gameExists && !fishExists) {
+    log('ℹ️', 'No old databases found. Nothing to migrate.');
+    return false;
+  }
+
+  log('📊', 'Found old databases:');
+  if (profileExists) log('  ✓', 'profile.db');
+  if (gameExists) log('  ✓', 'game.db');
+  if (fishExists) log('  ✓', 'fish.db');
+
+  return true;
+}
+
+function checkNewDatabases(): void {
+  const userExists = existsSync(NEW_USER_DB);
+  const gameExists = existsSync(NEW_GAME_DB);
+
+  if (userExists || gameExists) {
+    error('New databases already exist!');
+    if (userExists) error('  - userData.db already exists');
+    if (gameExists) error('  - gameData.db already exists');
+    error('\nPlease remove or rename these files before running the migration.');
+    process.exit(1);
+  }
+}
+
+function createBackups(): void {
+  log('💾', 'Creating backups...');
+
+  if (existsSync(OLD_PROFILE_DB)) {
+    copyFileSync(OLD_PROFILE_DB, BACKUP_PROFILE_DB);
+    log('  ✓', 'Backed up profile.db');
+  }
+
+  if (existsSync(OLD_GAME_DB)) {
+    copyFileSync(OLD_GAME_DB, BACKUP_GAME_DB);
+    log('  ✓', 'Backed up game.db');
+  }
+
+  if (existsSync(OLD_FISH_DB)) {
+    copyFileSync(OLD_FISH_DB, BACKUP_FISH_DB);
+    log('  ✓', 'Backed up fish.db');
+  }
+
+  log('✅', 'Backups created successfully');
+}
+
+function migrateUserData(): void {
+  log('👤', 'Migrating user data...');
+
+  // Copy profile.db to userData.db
+  if (existsSync(OLD_PROFILE_DB)) {
+    copyFileSync(OLD_PROFILE_DB, NEW_USER_DB);
+    log('  ✓', 'Copied profile.db to userData.db');
+  } else {
+    // Create new userData.db from schema
+    const userDb = new Database(NEW_USER_DB);
+    const schema = readFileSync(USER_SCHEMA_PATH, 'utf-8');
+    userDb.exec(schema);
+    userDb.close();
+    log('  ✓', 'Created new userData.db from schema');
+  }
+
+  // Migrate user tracking tables from game.db if it exists
+  if (existsSync(OLD_GAME_DB)) {
+    const userDb = new Database(NEW_USER_DB);
+    const gameDb = new Database(OLD_GAME_DB, { readonly: true });
+
+    userDb.pragma('foreign_keys = OFF');
+
+    try {
+      // Tables to migrate from game.db to userData.db
+      const trackingTables = [
+        'gathered_items',
+        'crafted_items',
+        'obtained_mounts',
+        'obtained_companions',
+        'obtained_orchestrion',
+      ];
+
+      for (const table of trackingTables) {
+        // Check if table exists in source
+        const tableExists = gameDb
+          .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`)
+          .get(table);
+
+        if (tableExists) {
+          // Get all rows from source table
+          const rows = gameDb.prepare(`SELECT * FROM ${table}`).all();
+
+          if (rows.length > 0) {
+            // Get column names
+            const firstRow = rows[0] as Record<string, any>;
+            const columns = Object.keys(firstRow);
+            const placeholders = columns.map(() => '?').join(', ');
+
+            // Insert into destination
+            const insert = userDb.prepare(
+              `INSERT OR REPLACE INTO ${table} (${columns.join(', ')}) VALUES (${placeholders})`
+            );
+
+            const insertMany = userDb.transaction((rowsToInsert: any[]) => {
+              for (const row of rowsToInsert) {
+                insert.run(...columns.map((col) => row[col]));
+              }
+            });
+
+            insertMany(rows);
+            log('  ✓', `Migrated ${rows.length} rows from ${table}`);
+          } else {
+            log('  ℹ️', `No data to migrate from ${table}`);
+          }
+        }
+      }
+    } catch (err) {
+      error(`Error migrating user tracking data: ${err}`);
+      throw err;
+    } finally {
+      userDb.pragma('foreign_keys = ON');
+      gameDb.close();
+      userDb.close();
+    }
+  }
+
+  log('✅', 'User data migration complete');
+}
+
+function migrateGameData(): void {
+  log('🎮', 'Migrating game data...');
+
+  // Create new gameData.db from schema
+  const gameDb = new Database(NEW_GAME_DB);
+  const schema = readFileSync(GAME_SCHEMA_PATH, 'utf-8');
+  gameDb.exec(schema);
+
+  gameDb.pragma('foreign_keys = OFF');
+
+  try {
+    // Copy all tables from old game.db except user tracking tables
+    if (existsSync(OLD_GAME_DB)) {
+      const oldGameDb = new Database(OLD_GAME_DB, { readonly: true });
+
+      // Get all table names
+      const tables = oldGameDb
+        .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`)
+        .all() as { name: string }[];
+
+      const userTrackingTables = [
+        'gathered_items',
+        'crafted_items',
+        'obtained_mounts',
+        'obtained_companions',
+        'obtained_orchestrion',
+      ];
+
+      for (const { name } of tables) {
+        // Skip user tracking tables
+        if (userTrackingTables.includes(name)) {
+          log('  ⏭️', `Skipping user tracking table: ${name}`);
+          continue;
+        }
+
+        // Skip views
+        if (name.startsWith('v_')) {
+          continue;
+        }
+
+        const rows = oldGameDb.prepare(`SELECT * FROM ${name}`).all();
+
+        if (rows.length > 0) {
+          const firstRow = rows[0] as Record<string, any>;
+          const columns = Object.keys(firstRow);
+          const placeholders = columns.map(() => '?').join(', ');
+
+          const insert = gameDb.prepare(
+            `INSERT OR REPLACE INTO ${name} (${columns.join(', ')}) VALUES (${placeholders})`
+          );
+
+          const insertMany = gameDb.transaction((rowsToInsert: any[]) => {
+            for (const row of rowsToInsert) {
+              insert.run(...columns.map((col) => row[col]));
+            }
+          });
+
+          insertMany(rows);
+          log('  ✓', `Copied ${rows.length} rows from ${name}`);
+        }
+      }
+
+      oldGameDb.close();
+    }
+
+    // Copy all tables from old fish.db
+    if (existsSync(OLD_FISH_DB)) {
+      const oldFishDb = new Database(OLD_FISH_DB, { readonly: true });
+
+      const tables = oldFishDb
+        .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`)
+        .all() as { name: string }[];
+
+      for (const { name } of tables) {
+        const rows = oldFishDb.prepare(`SELECT * FROM ${name}`).all();
+
+        if (rows.length > 0) {
+          const firstRow = rows[0] as Record<string, any>;
+          const columns = Object.keys(firstRow);
+          const placeholders = columns.map(() => '?').join(', ');
+
+          const insert = gameDb.prepare(
+            `INSERT OR REPLACE INTO ${name} (${columns.join(', ')}) VALUES (${placeholders})`
+          );
+
+          const insertMany = gameDb.transaction((rowsToInsert: any[]) => {
+            for (const row of rowsToInsert) {
+              insert.run(...columns.map((col) => row[col]));
+            }
+          });
+
+          insertMany(rows);
+          log('  ✓', `Copied ${rows.length} rows from fish.${name}`);
+        }
+      }
+
+      oldFishDb.close();
+    }
+  } catch (err) {
+    error(`Error migrating game data: ${err}`);
+    throw err;
+  } finally {
+    gameDb.pragma('foreign_keys = ON');
+    gameDb.close();
+  }
+
+  log('✅', 'Game data migration complete');
+}
+
+async function main() {
+  console.log('🔄 Database Migration Tool');
+  console.log('=========================\n');
+
+  // Check if old databases exist
+  if (!checkOldDatabases()) {
+    return;
+  }
+
+  // Check if new databases already exist
+  checkNewDatabases();
+
+  // Create backups
+  createBackups();
+
+  // Migrate user data
+  migrateUserData();
+
+  // Migrate game data
+  migrateGameData();
+
+  console.log('\n=========================');
+  console.log('✅ Migration complete!');
+  console.log('\nNew databases created:');
+  console.log(`  - ${NEW_USER_DB}`);
+  console.log(`  - ${NEW_GAME_DB}`);
+  console.log('\nBackups saved as:');
+  if (existsSync(BACKUP_PROFILE_DB)) console.log(`  - ${BACKUP_PROFILE_DB}`);
+  if (existsSync(BACKUP_GAME_DB)) console.log(`  - ${BACKUP_GAME_DB}`);
+  if (existsSync(BACKUP_FISH_DB)) console.log(`  - ${BACKUP_FISH_DB}`);
+  console.log('\nYou can now safely delete the old databases if everything works correctly.');
+  console.log('=========================\n');
+}
+
+main().catch((err) => {
+  error(`Migration failed: ${err}`);
+  process.exit(1);
+});

--- a/scripts/parse-quest-data.ts
+++ b/scripts/parse-quest-data.ts
@@ -24,7 +24,7 @@ const CSV_DIR = join(DATA_DIR, 'ffxiv-datamining', 'csv');
 const SCHEMA_DIR = join(DATA_DIR, 'game-schemas');
 const OUTPUT_FILE = join(DATA_DIR, 'quest-data.json');
 const FISH_DATA_FILE = join(DATA_DIR, 'fish-data.json');
-const FISH_DB_FILE = join(DATA_DIR, 'fish.db');
+const FISH_DB_FILE = join(DATA_DIR, 'gameData.db');
 
 async function parseQuestData(): Promise<void> {
   console.log('🎮 Parsing quest data from CSV files...\n');

--- a/scripts/seed-achievement-db.ts
+++ b/scripts/seed-achievement-db.ts
@@ -10,7 +10,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 
 const CSV_PATH = join(process.cwd(), 'data', 'ffxiv-datamining', 'csv', 'Achievement.csv');
-const DB_PATH = join(process.cwd(), 'data', 'game.db');
+const DB_PATH = join(process.cwd(), 'data', 'gameData.db');
 
 interface AchievementRow {
   key: string;

--- a/scripts/seed-fish-db.ts
+++ b/scripts/seed-fish-db.ts
@@ -21,7 +21,7 @@ const __dirname = dirname(__filename);
 
 const DATA_DIR = join(__dirname, '..', 'data');
 const INPUT_FILE = join(DATA_DIR, 'fish-data.json');
-const DB_FILE = join(DATA_DIR, 'fish.db');
+const DB_FILE = join(DATA_DIR, 'gameData.db');
 
 function createSchema(db: Database.Database): void {
   console.log('📐 Creating database schema...');

--- a/scripts/seed-game-data.ts
+++ b/scripts/seed-game-data.ts
@@ -18,7 +18,7 @@ import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 
 const CSV_DIR = join(process.cwd(), 'data', 'ffxiv-datamining', 'csv');
-const DB_PATH = join(process.cwd(), 'data', 'game.db');
+const DB_PATH = join(process.cwd(), 'data', 'gameData.db');
 
 interface CSVRow {
   [key: string]: string;
@@ -74,7 +74,7 @@ function loadCSV(filename: string): CSVRow[] | null {
 function initializeSchema(db: Database.Database) {
   console.log('\n📋 Initializing database schema...');
 
-  const schemaPath = join(process.cwd(), 'data', 'game-data-schema.sql');
+  const schemaPath = join(process.cwd(), 'data', 'gameData-schema.sql');
 
   if (!existsSync(schemaPath)) {
     console.error('❌ Schema file not found:', schemaPath);

--- a/scripts/seed-item-names.ts
+++ b/scripts/seed-item-names.ts
@@ -21,7 +21,7 @@ const __dirname = dirname(__filename);
 
 const DATA_DIR = join(__dirname, '..', 'data');
 const CSV_DIR = join(DATA_DIR, 'ffxiv-datamining', 'csv');
-const DB_FILE = join(DATA_DIR, 'fish.db');
+const DB_FILE = join(DATA_DIR, 'gameData.db');
 const ITEM_CSV = join(CSV_DIR, 'Item.csv');
 
 function main() {

--- a/scripts/seed-quest-db.ts
+++ b/scripts/seed-quest-db.ts
@@ -19,7 +19,7 @@ const __dirname = dirname(__filename);
 
 const DATA_DIR = join(__dirname, '..', 'data');
 const INPUT_FILE = join(DATA_DIR, 'quest-data.json');
-const DB_FILE = join(DATA_DIR, 'game.db');
+const DB_FILE = join(DATA_DIR, 'gameData.db');
 
 interface QuestData {
   id: number;

--- a/scripts/seed-title-db.ts
+++ b/scripts/seed-title-db.ts
@@ -10,7 +10,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 
 const CSV_PATH = join(process.cwd(), 'data', 'ffxiv-datamining', 'csv', 'Title.csv');
-const DB_PATH = join(process.cwd(), 'data', 'game.db');
+const DB_PATH = join(process.cwd(), 'data', 'gameData.db');
 
 interface TitleRow {
   key: string;

--- a/scripts/seed-weather-names.ts
+++ b/scripts/seed-weather-names.ts
@@ -18,7 +18,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const DATA_DIR = join(__dirname, '..', 'data');
-const DB_FILE = join(DATA_DIR, 'fish.db');
+const DB_FILE = join(DATA_DIR, 'gameData.db');
 const FISH_DATA_FILE = join(DATA_DIR, 'fish-data.json');
 
 function main() {

--- a/src/parsers/lodestoneAchievementParser.ts
+++ b/src/parsers/lodestoneAchievementParser.ts
@@ -23,7 +23,7 @@ export interface ParseResult {
   unmatchedNames: string[];
 }
 
-const GAME_DB_PATH = join(process.cwd(), 'data', 'game.db');
+const GAME_DB_PATH = join(process.cwd(), 'data', 'gameData.db');
 
 /**
  * Parse Lodestone achievement text format

--- a/src/services/achievementTracker.ts
+++ b/src/services/achievementTracker.ts
@@ -8,7 +8,7 @@ import Database from 'better-sqlite3';
 import { join } from 'path';
 import type { Achievement, AchievementSearchOptions } from '../types/title.js';
 
-const DB_PATH = join(process.cwd(), 'data', 'game.db');
+const DB_PATH = join(process.cwd(), 'data', 'gameData.db');
 
 export class AchievementTrackerService {
   private db: Database.Database;

--- a/src/services/collectiblesService.ts
+++ b/src/services/collectiblesService.ts
@@ -38,7 +38,7 @@ export class CollectiblesService {
   private db: Database.Database;
 
   constructor(dbPath?: string) {
-    const path = dbPath || join(process.cwd(), 'data', 'game.db');
+    const path = dbPath || join(process.cwd(), 'data', 'gameData.db');
     this.db = new Database(path, { readonly: true });
     this.db.pragma('foreign_keys = ON');
   }
@@ -211,7 +211,7 @@ export class CollectiblesService {
     obtainedFrom?: string,
     notes?: string
   ): void {
-    const writeDb = new Database(join(process.cwd(), 'data', 'game.db'));
+    const writeDb = new Database(join(process.cwd(), 'data', 'gameData.db'));
 
     try {
       writeDb
@@ -383,7 +383,7 @@ export class CollectiblesService {
     obtainedFrom?: string,
     notes?: string
   ): void {
-    const writeDb = new Database(join(process.cwd(), 'data', 'game.db'));
+    const writeDb = new Database(join(process.cwd(), 'data', 'gameData.db'));
 
     try {
       writeDb
@@ -571,7 +571,7 @@ export class CollectiblesService {
     obtainedFrom?: string,
     notes?: string
   ): void {
-    const writeDb = new Database(join(process.cwd(), 'data', 'game.db'));
+    const writeDb = new Database(join(process.cwd(), 'data', 'gameData.db'));
 
     try {
       writeDb

--- a/src/services/craftingService.ts
+++ b/src/services/craftingService.ts
@@ -29,7 +29,7 @@ export class CraftingService {
   private db: Database.Database;
 
   constructor(dbPath?: string) {
-    const path = dbPath || join(process.cwd(), 'data', 'game.db');
+    const path = dbPath || join(process.cwd(), 'data', 'gameData.db');
     this.db = new Database(path, { readonly: true });
     this.db.pragma('foreign_keys = ON');
   }
@@ -485,7 +485,7 @@ export class CraftingService {
     collectibility?: number,
     notes?: string
   ): void {
-    const writeDb = new Database(join(process.cwd(), 'data', 'game.db'));
+    const writeDb = new Database(join(process.cwd(), 'data', 'gameData.db'));
 
     try {
       writeDb

--- a/src/services/fishTracker.ts
+++ b/src/services/fishTracker.ts
@@ -15,7 +15,7 @@ import {
 } from '../utils/weatherForecast.js';
 
 // Default database path (relative to project root)
-const DB_PATH = join(process.cwd(), 'data', 'fish.db');
+const DB_PATH = join(process.cwd(), 'data', 'gameData.db');
 
 export class FishTrackerService {
   private db: Database.Database;

--- a/src/services/gatheringService.ts
+++ b/src/services/gatheringService.ts
@@ -28,7 +28,7 @@ export class GatheringService {
   private db: Database.Database;
 
   constructor(dbPath?: string) {
-    const path = dbPath || join(process.cwd(), 'data', 'game.db');
+    const path = dbPath || join(process.cwd(), 'data', 'gameData.db');
     this.db = new Database(path, { readonly: true });
     this.db.pragma('foreign_keys = ON');
   }
@@ -321,7 +321,7 @@ export class GatheringService {
     isHq: boolean = false,
     notes?: string
   ): void {
-    const writeDb = new Database(join(process.cwd(), 'data', 'game.db'));
+    const writeDb = new Database(join(process.cwd(), 'data', 'gameData.db'));
 
     try {
       writeDb

--- a/src/services/intelligentSync.ts
+++ b/src/services/intelligentSync.ts
@@ -7,7 +7,7 @@
 import Database from 'better-sqlite3';
 import { join } from 'path';
 
-const GAME_DB_PATH = join(process.cwd(), 'data', 'game.db');
+const GAME_DB_PATH = join(process.cwd(), 'data', 'gameData.db');
 
 export interface QuestInference {
   questId: number;

--- a/src/services/itemService.ts
+++ b/src/services/itemService.ts
@@ -25,7 +25,7 @@ export class ItemService {
   private db: Database.Database;
 
   constructor(dbPath?: string) {
-    const path = dbPath || join(process.cwd(), 'data', 'game.db');
+    const path = dbPath || join(process.cwd(), 'data', 'gameData.db');
     this.db = new Database(path, { readonly: true });
     this.db.pragma('foreign_keys = ON');
   }
@@ -220,7 +220,7 @@ export class ItemService {
     sourceName?: string,
     sourceDetails?: ItemSourceDetails
   ): void {
-    const insertDb = new Database(join(process.cwd(), 'data', 'game.db'));
+    const insertDb = new Database(join(process.cwd(), 'data', 'gameData.db'));
 
     insertDb
       .prepare(
@@ -245,7 +245,7 @@ export class ItemService {
     quantityRequired?: number,
     useDetails?: ItemUseDetails
   ): void {
-    const insertDb = new Database(join(process.cwd(), 'data', 'game.db'));
+    const insertDb = new Database(join(process.cwd(), 'data', 'gameData.db'));
 
     insertDb
       .prepare(

--- a/src/services/questFishInference.ts
+++ b/src/services/questFishInference.ts
@@ -7,8 +7,8 @@
 import Database from 'better-sqlite3';
 import { join } from 'path';
 
-const GAME_DB_PATH = join(process.cwd(), 'data', 'game.db');
-const PROFILE_DB_PATH = join(process.cwd(), 'data', 'profile.db');
+const GAME_DB_PATH = join(process.cwd(), 'data', 'gameData.db');
+const PROFILE_DB_PATH = join(process.cwd(), 'data', 'userData.db');
 
 export interface FishInference {
   fishId: number;

--- a/src/services/questTracker.ts
+++ b/src/services/questTracker.ts
@@ -9,7 +9,7 @@ import { join } from 'path';
 import type { Quest, QuestSearchOptions } from '../types/quest.js';
 
 // Default database path (relative to project root)
-const DB_PATH = join(process.cwd(), 'data', 'game.db');
+const DB_PATH = join(process.cwd(), 'data', 'gameData.db');
 
 export class QuestTrackerService {
   private db: Database.Database;

--- a/src/services/titleTracker.ts
+++ b/src/services/titleTracker.ts
@@ -8,7 +8,7 @@ import Database from 'better-sqlite3';
 import { join } from 'path';
 import type { Title, TitleSearchOptions } from '../types/title.js';
 
-const DB_PATH = join(process.cwd(), 'data', 'game.db');
+const DB_PATH = join(process.cwd(), 'data', 'gameData.db');
 
 export class TitleTrackerService {
   private db: Database.Database;


### PR DESCRIPTION
This commit consolidates the three-database structure (profile.db, game.db, fish.db) into a cleaner two-database architecture that better separates concerns:

Database Changes:
- gameData.db: Consolidated read-only game reference data
  * Combines all data from game.db (items, recipes, gathering, collectibles)
  * Integrates fish.db (fish, spots, weather, zones)
  * Single source for all FFXIV game reference data

- userData.db: Consolidated user-specific progress data
  * Replaces profile.db for character and progress tracking
  * Includes user tracking tables from game.db (gathered_items, crafted_items, etc.)
  * Single database for import/export/sync operations

Schema Files:
- Created data/gameData-schema.sql with consolidated game reference schema
- Created data/userData-schema.sql with user progress schema
- Preserved original schemas for reference/migration

Code Updates:
- Updated all services to use new database paths
- Modified PlayerProfileService to use two databases instead of three
- Updated all seeding scripts to populate gameData.db
- Bulk replaced database paths across services, parsers, and scripts

Migration Support:
- Created scripts/migrate-to-consolidated-db.ts for automatic migration
- Created scripts/init-user-db.ts for new user initialization
- Migration includes automatic backups of old databases

Documentation:
- Updated README.md with new database architecture diagram
- Added database structure documentation
- Included migration instructions for existing users

Benefits:
- Clearer separation between game data and user data
- Simplified backup/sync (only userData.db needs to be synced)
- Better organization (fish data no longer in separate database)
- Easier to understand for new contributors